### PR TITLE
Don't throw error even if current token is null

### DIFF
--- a/android/src/main/kotlin/com/linecorp/flutter_line_sdk/LineSdkWrapper.kt
+++ b/android/src/main/kotlin/com/linecorp/flutter_line_sdk/LineSdkWrapper.kt
@@ -182,11 +182,7 @@ class LineSdkWrapper(
                     )
                 )
             } else {
-                result.error(
-                    lineApiResponse.responseCode.name,
-                    lineApiResponse.errorData.message,
-                    null
-                )
+                result.error(null)
             }
         }
     }

--- a/android/src/main/kotlin/com/linecorp/flutter_line_sdk/LineSdkWrapper.kt
+++ b/android/src/main/kotlin/com/linecorp/flutter_line_sdk/LineSdkWrapper.kt
@@ -182,7 +182,7 @@ class LineSdkWrapper(
                     )
                 )
             } else {
-                result.error(null)
+                result.success(null)
             }
         }
     }


### PR DESCRIPTION
In iOS, currentAccessToken does not throw error even if token is null, but currently throw in android.
I want the same behavior on both OS.