### PR TITLE
Apply mutiDex implementation in android versions below 5.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,7 +33,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 17
+        minSdkVersion 18
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-proguard-rules.pro'
     }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -38,7 +38,7 @@ android {
 
     defaultConfig {
         applicationId "com.linecorp.linesdk.sample"
-        minSdkVersion 17
+        minSdkVersion 18
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name=".MyApplication"
         android:label="flutter_line_sdk_example"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/example/android/app/src/main/kotlin/com/linecorp/linesdk/sample/MyApplication.kt
+++ b/example/android/app/src/main/kotlin/com/linecorp/linesdk/sample/MyApplication.kt
@@ -1,0 +1,13 @@
+package com.linecorp.linesdk.sample
+
+import android.content.Context
+import androidx.multidex.MultiDex
+import io.flutter.app.FlutterApplication
+
+
+class MyApplication : FlutterApplication() {
+    override fun attachBaseContext(base: Context) {
+        super.attachBaseContext(base)
+        MultiDex.install(this)
+    }
+}


### PR DESCRIPTION
Fix of https://github.com/line/flutter_line_sdk/issues/28

* align example minSdkVersion to line sdk android version.
* add necessary multiDex implmentation so that the example won't crash under android versions below 5.0.