### PR TITLE
make sure android returns idtoken raw string as iOS platform does.

### DIFF
--- a/android/src/main/kotlin/com/linecorp/flutter_line_sdk/LineSdkWrapper.kt
+++ b/android/src/main/kotlin/com/linecorp/flutter_line_sdk/LineSdkWrapper.kt
@@ -119,7 +119,7 @@ class LineSdkWrapper(
         }
 
         val result = LineLoginApi.getLoginResultFromIntent(intent)
-        runIfDebugBuild { Log.d(TAG, "login result:$result") }
+        //runIfDebugBuild { Log.d(TAG, "login result:$result") }
 
         when(result.responseCode) {
             LineApiResponseCode.SUCCESS -> {

--- a/android/src/main/kotlin/com/linecorp/flutter_line_sdk/model/AccessToken.kt
+++ b/android/src/main/kotlin/com/linecorp/flutter_line_sdk/model/AccessToken.kt
@@ -15,9 +15,7 @@ data class AccessToken(
 ) {
     companion object {
         fun convertFromLineLoginResult(loginResult: LineLoginResult): AccessToken? {
-            val lineIdTokenString = loginResult.lineIdToken?.let {
-                Gson().toJson(it)
-            } ?: ""
+            val lineIdTokenString = loginResult.lineIdToken?.rawString ?: ""
             val accessToken = loginResult.lineCredential?.accessToken ?: return null
             return AccessToken(
                 accessToken.tokenString,


### PR DESCRIPTION
return the same content format as iOS when developer query `result.accessToken.idTokenRaw` after calling `LineSDK.instance.login`.

For more details, please check https://github.com/line/flutter_line_sdk/issues/31.