### PR TITLE
Add an email getter for access token

### DIFF
--- a/example/lib/src/screen/home_page.dart
+++ b/example/lib/src/screen/home_page.dart
@@ -150,7 +150,7 @@ class _HomePageState extends State<HomePage>
       final accessToken = await LineSDK.instance.currentAccessToken;
 
       final idToken = result.accessToken.idToken;
-      final userEmail = (idToken != null) ? idToken['email'] : null;
+      final userEmail = result.accessToken.email;
 
       setState(() {
         _userProfile = result.userProfile;
@@ -167,6 +167,7 @@ class _HomePageState extends State<HomePage>
       await LineSDK.instance.logout();
       setState(() {
         _userProfile = null;
+        _userEmail = null;
         _accessToken = null;
       });
     } on PlatformException catch (e) {

--- a/example/lib/src/screen/home_page.dart
+++ b/example/lib/src/screen/home_page.dart
@@ -149,7 +149,6 @@ class _HomePageState extends State<HomePage>
           .login(scopes: _selectedScopes.toList(), option: loginOption);
       final accessToken = await LineSDK.instance.currentAccessToken;
 
-      final idToken = result.accessToken.idToken;
       final userEmail = result.accessToken.email;
 
       setState(() {

--- a/lib/src/model/access_token.dart
+++ b/lib/src/model/access_token.dart
@@ -103,7 +103,7 @@ class AccessToken {
   /// with you. Both "openid" and "email" scopes are required to get the user email.
   ///
   /// If you are not applying an ID Token when login, or the user does not set
-  /// the email for the LINE account, or the user refused to granted your access,
+  /// the email for the LINE account, or the user refuses to grant your access,
   /// `null` is returned.
   String get email => idToken?['email'];
 }

--- a/lib/src/model/access_token.dart
+++ b/lib/src/model/access_token.dart
@@ -97,4 +97,13 @@ class AccessToken {
   /// The expected authorization type when this token is used in a request
   /// header. Fixed to `Bearer` for now.
   String get tokenType => _data['token_type'];
+
+  /// The email address set by the user. This value only exists when `idToken` is
+  /// valid and the user has set the email address in LINE and agreed to share it
+  /// with you. Both "openid" and "email" scopes are required to get the user email.
+  ///
+  /// If you are not applying an ID Token when login, or the user does not set
+  /// the email for the LINE account, or the user refused to granted your access,
+  /// `null` is returned.
+  String get email => idToken?['email'];
 }

--- a/lib/src/model/access_token.dart
+++ b/lib/src/model/access_token.dart
@@ -105,5 +105,5 @@ class AccessToken {
   /// If you are not applying an ID Token when login, or the user does not set
   /// the email for the LINE account, or the user refuses to grant your access,
   /// `null` is returned.
-  String get email => idToken?['email'];
+  String? get email => idToken?['email'];
 }


### PR DESCRIPTION
For #46 and #57

It would be easier for developers to find a way to get user's email in the ID Token.