### PR TITLE
Upgrade the deployment_target for iOS to iOS 11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.1
+
+* Algin the deploy target of iOS with LINE SDK Swift to iOS 11.0. This allows the LINE Flutter SDK continue to compile with the latest LINE SDK. [#65](https://github.com/line/flutter_line_sdk/issues/65)
+
 ## 2.3.0
 
 ### Added

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -28,7 +28,7 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
-  platform :ios, '10.0'
+  platform :ios, '11.0'
 
   use_frameworks!
   use_modular_headers!

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -3,9 +3,9 @@ PODS:
   - flutter_line_sdk (2.3.0):
     - Flutter
     - LineSDKSwift (~> 5.3)
-  - LineSDKSwift (5.4.0):
-    - LineSDKSwift/Core (= 5.4.0)
-  - LineSDKSwift/Core (5.4.0)
+  - LineSDKSwift (5.9.0):
+    - LineSDKSwift/Core (= 5.9.0)
+  - LineSDKSwift/Core (5.9.0)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -23,9 +23,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
-  flutter_line_sdk: ffbd219457120ca500b4fba2a5fd818dee21a17a
-  LineSDKSwift: 25bc89f5f08578a39ec2dcb36ee58e2f920e893c
+  flutter_line_sdk: 69e235163c2b481790e68b2806c9f8c49a5f5eb2
+  LineSDKSwift: 97d6306ca17ae41520f29eb5dff4077dd81f08b2
 
-PODFILE CHECKSUM: f16cee13212746272bf6b0bb111e74a51363cd78
+PODFILE CHECKSUM: 286cd794da909470ef132faa2b6b4260996f1599
 
 COCOAPODS: 1.11.3

--- a/ios/flutter_line_sdk.podspec
+++ b/ios/flutter_line_sdk.podspec
@@ -17,5 +17,5 @@ A Flutter plugin using the LINE SDKs with Dart in Flutter apps.
   s.swift_version         = "4.2"
   s.swift_versions        = ['4.2', '5.0']
 
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '11.0'
 end

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,35 +21,28 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,28 +59,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -99,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -120,35 +113,28 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=1.12.0"


### PR DESCRIPTION
This fixes #65 and later we can release a version based on it.

As the similar policy of https://github.com/line/line-sdk-ios-swift/pull/178 and [LINE SDK 5.9.0](https://github.com/line/line-sdk-ios-swift/releases/tag/5.9.0), the iOS 10.0 users are very few so we want to keep the same major version unchanged to encourage more users to upgrade.