### PR TITLE
Update Kotlin Version to 1.5.32

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.linecorp.flutter_line_sdk'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.32'
     repositories {
         google()
         jcenter()
@@ -27,7 +27,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.32'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
## Issue

- close #68

## Overview

I tried to use the `flutter_line_sdk` library but encountered an error.

To resolve the issue, please update the Kotlin version to 1.5.32, which is the latest in the 1.5.x family.
Additionally, set compileSdkVersion to 31 to ensure that the example Android build passes successfully.

Supplementary information included the following error message.

```shell
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:checkDebugAarMetadata'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > One or more issues found when checking AAR metadata values:

     The minCompileSdk (31) specified in a
     dependency's AAR metadata (META-INF/com/android/build/gradle/aar-metadata.properties)
     is greater than this module's compileSdkVersion (android-28).
     Dependency: androidx.window:window-java:1.0.0-beta04.
     AAR metadata file: /Users/r_takeuchi/.gradle/caches/transforms-3/b5421194365f75bbfbaee57983ed7804/transformed/jetified-window-java-1.0.0-beta04/META-INF/com/android/build/gradle/aar-metadata.properties.

     The minCompileSdk (31) specified in a
     dependency's AAR metadata (META-INF/com/android/build/gradle/aar-metadata.properties)
     is greater than this module's compileSdkVersion (android-28).
     Dependency: androidx.window:window:1.0.0-beta04.
     AAR metadata file: /Users/r_takeuchi/.gradle/caches/transforms-3/d1d2a299e8fde4c5c49d9224fa1901d6/transformed/jetified-window-1.0.0-beta04/META-INF/com/android/build/gradle/aar-metadata.properties.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 757ms

┌─ Flutter Fix ──────────────────────────────────────────────────────────────────────────────┐
│ [!] Your project requires a higher compileSdkVersion.                                      │
│ Fix this issue by bumping the compileSdkVersion in                                         │
│ /Users/xxx/xxx/flutter_line_sdk/example/android/app/build.gradle: │
│ android {                                                                                  │
│   compileSdkVersion 31                                                                     │
│ }                                                                                          │
└────────────────────────────────────────────────────────────────────────────────────────────┘
Exception: Gradle task assembleDebug failed with exit code 1
```