### PR TITLE
Bump Android LINE SDK version to 5.9.1 and minSdk to 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,24 @@ target 'Runner' do
 
 #### Android
 
-No specific settings are required.
+To ensure compatibility with the latest features, you need to update the `minSdk` version in your app's `build.gradle` file to `24` or higher. 
+
+Here's how you can do it:
+
+1. Open your app's `build.gradle` file.
+2. Locate the `android` block, and within it, find the `defaultConfig` block.
+3. In the `defaultConfig` block, replace the current `minSdk` value with `24`.
+
+Here's a diff to show what your changes might look like:
+
+```diff
+android {
+    defaultConfig {
+-        minSdk flutter.minSdkVersion
++        minSdk 24
+    }
+}
+```
 
 ### Importing and using
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.1'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 
@@ -26,13 +26,13 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 24
+        minSdk 24
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-proguard-rules.pro'
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,7 +33,7 @@ android {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 24
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles 'consumer-proguard-rules.pro'
     }
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-    implementation('com.linecorp.linesdk:linesdk:5.8.1') {
+    implementation('com.linecorp.linesdk:linesdk:5.9.1') {
         exclude group: 'androidx.lifecycle', module: 'lifecycle-viewmodel-ktx'
     }
     implementation 'com.google.code.gson:gson:2.8.5'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,6 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 
-
 }
 
 rootProject.allprojects {
@@ -27,7 +26,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdk 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -38,8 +38,8 @@ android {
 
     defaultConfig {
         applicationId "com.linecorp.linesdk.sample"
-        minSdkVersion 24
-        targetSdkVersion 31
+        minSdk 24
+        targetSdk 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.1'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip


### PR DESCRIPTION
- Upgrade the Android LINE SDK wrapped in Flutter LINE SDK from `5.8.1` to `5.9.1`
- Increase the `minSdk` in the Flutter LINE SDK for Android to `24`
  - This aligns with the Android LINE SDK: https://github.com/line/line-sdk-android/blob/v5.9.1/line-sdk/build.gradle#L16
- In the README file, describe the requirement for the host app to set the `minSdk` to `24` or higher.
- Change the `compileSdk` to `33`, the same as the Android LINE SDK.

