### PR TITLE
Update to use an HTTP source in pod spec

### DIFF
--- a/ios/flutter_line_sdk.podspec
+++ b/ios/flutter_line_sdk.podspec
@@ -9,8 +9,8 @@ Swift.
   s.homepage         = 'https://developers.line.biz'
   s.license          = { :type => 'Apache', :file => '../LICENSE' }
   s.author           = { 'LINE' => 'dl_linesdk_cocoapods@linecorp.com' }
-  s.source           = { :http => 'file:' + __dir__ }
-  s.source_files = 'flutter_line_sdk/Sources/flutter_line_sdk/**/*.swift'
+  s.source           = { :http => 'https://github.com/line/flutter_line_sdk' }
+  s.source_files     = 'flutter_line_sdk/Sources/flutter_line_sdk/**/*.swift'
   s.dependency 'Flutter'
   s.dependency 'LineSDKSwift', '~> 5.3'
 


### PR DESCRIPTION
Fixes #121

Since Pod installations in Flutter packages occur locally, the `source` key is unnecessary. 

Directing it to a fixed URL, like our repository, is advisable. Official native plugins ([like this](https://github.com/flutter/packages/blob/main/packages/camera/camera_avfoundation/ios/camera_avfoundation.podspec#L14)) are implementing this approach, indicating it's both safe and recommended.