### PR TITLE
Remove 6.0 lang support since it requires Flutter support

### DIFF
--- a/ios/flutter_line_sdk.podspec
+++ b/ios/flutter_line_sdk.podspec
@@ -15,7 +15,7 @@ Swift.
   s.dependency 'LineSDKSwift', '~> 5.13'
 
   s.swift_version         = "5.0"
-  s.swift_versions        = ["6.0", "5.0", "4.2"]
+  s.swift_versions        = ["5.0", "4.2"]
 
   s.ios.deployment_target = '13.0'
 end


### PR DESCRIPTION
This fixes #130 

This doesn't fix the issue at its core, it only disables the strict error mode from Swift 6. 

We will see what else needs to be done after Flutter completely drops CocoaPods support.