### PR TITLE
Update Android SDK to 5.11.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,7 +54,7 @@ android {
 }
 
 dependencies {
-    implementation('com.linecorp.linesdk:linesdk:5.11.0') {
+    implementation('com.linecorp.linesdk:linesdk:5.11.1') {
         exclude group: 'androidx.lifecycle', module: 'lifecycle-viewmodel-ktx'
         exclude group: 'androidx.lifecycle', module: 'lifecycle-extensions'
     }


### PR DESCRIPTION
Fix a potential issue in release build of flutter SDK

`
ERROR: R8: Missing class com.linecorp.linesdk.BR (referenced from: void com.linecorp.linesdk.databinding.OpenChatInfoFragmentBindingImpl.setViewModel(com.linecorp.linesdk.openchat.ui.OpenChatInfoViewModel) and 1 other context) 
`

To solve faill when release with obfocated