### PR TITLE
Migrate Android build to built-in Kotlin and align with the Flutter 3.44 toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ For more examples, see the [example app](https://github.com/line/flutter_line_sd
 
 From version 2.0, `flutter_line_sdk` supports [null safety](https://dart.dev/null-safety). If you are still seeking a legacy version without null safety, check [version 1.3.0](https://github.com/line/flutter_line_sdk/releases/tag/1.3.0).
 
+- Flutter 3.44.0 or later. Version 3.0 relies on Flutter's [built-in Kotlin support](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin) for Android builds; if your project is still on an older Flutter version, use `flutter_line_sdk` 2.x instead.
 - iOS 13.0 or later as the deployment target
 - Android `minSdkVersion` set to 24 or higher (Android 7.0 or later)
 - [LINE Login channel linked to your app](https://developers.line.biz/en/docs/line-login/getting-started/)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,14 +1,14 @@
 group 'com.linecorp.flutter_line_sdk'
 
 buildscript {
-    ext.kotlin_version = '2.2.20'
+    ext.kotlin_version = '2.3.20'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.11.1'
+        classpath 'com.android.tools.build:gradle:9.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -21,11 +21,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-
-def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
-    apply plugin: 'kotlin-android'
-}
 
 android {
     if (project.android.hasProperty('namespace')) {
@@ -51,11 +46,14 @@ android {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
     }
+}
 
-    if (agpMajor < 9) {
-        kotlinOptions {
-            jvmTarget = '17'
-        }
+// The Kotlin Gradle plugin is applied by Flutter itself (built-in Kotlin,
+// available since Flutter 3.44). Applying it here again would trigger the
+// KGP deprecation warning and break under AGP 9+.
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 
@@ -65,7 +63,6 @@ dependencies {
         exclude group: 'androidx.lifecycle', module: 'lifecycle-extensions'
     }
     implementation 'com.google.code.gson:gson:2.8.5'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,14 +1,14 @@
 group 'com.linecorp.flutter_line_sdk'
 
 buildscript {
-    ext.kotlin_version = '1.7.21'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:8.11.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -31,7 +31,7 @@ android {
     if (project.android.hasProperty('namespace')) {
         namespace 'com.linecorp.flutter_line_sdk'
     }
-    compileSdk 33
+    compileSdk 36
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -48,13 +48,13 @@ android {
         disable 'InvalidPackage'
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     if (agpMajor < 9) {
         kotlinOptions {
-            jvmTarget = '1.8'
+            jvmTarget = '17'
         }
     }
 }
@@ -66,6 +66,6 @@ dependencies {
     }
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.0.1"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.0.1"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1"
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,3 @@
 org.gradle.jvmargs=-Xmx1536M
-android.enableR8=true
 android.useAndroidX=true
 android.enableJetifier=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -24,7 +24,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace 'com.linecorp.linesdk.sample'
-    compileSdk 35
+    compileSdk flutter.compileSdkVersion
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -37,7 +37,7 @@ android {
     defaultConfig {
         applicationId "com.linecorp.linesdk.sample"
         minSdk 24
-        targetSdk 35
+        targetSdk flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -49,10 +48,6 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = '17'
-    }
-
     buildTypes {
         debug {
             // for proguard verification
@@ -67,6 +62,12 @@ android {
             )
             signingConfig signingConfigs.debug
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.linecorp.linesdk.sample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <application

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '2.0.0'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:8.4.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -4,3 +4,7 @@ android.enableJetifier=false
 android.nonTransitiveRClass=true
 android.nonFinalResIds=true
 android.enableR8.fullMode=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.11.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
+    id "com.android.application" version "9.0.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.3.20" apply false
 }
 
 include ":app"

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.4.0" apply false
-    id "org.jetbrains.kotlin.android" version "2.0.0" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
+		784666492D4C4C64000A1A5F /* FlutterFramework */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterFramework; path = Flutter/ephemeral/Packages/.packages/FlutterFramework; sourceTree = "<group>"; };
+		78DABEA22ED26510000E7860 /* flutter_line_sdk */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = flutter_line_sdk; path = ../../ios/flutter_line_sdk; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -89,6 +91,8 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78DABEA22ED26510000E7860 /* flutter_line_sdk */,
+				784666492D4C4C64000A1A5F /* FlutterFramework */,
 				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,

--- a/example/lib/src/app.dart
+++ b/example/lib/src/app.dart
@@ -4,16 +4,14 @@ import 'screen/api_page.dart';
 import 'screen/home_page.dart';
 
 class App extends StatelessWidget {
-  const App({Key? key}) : super(key: key);
+  const App({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: ThemeData(
         primaryColor: Colors.green,
-        tabBarTheme: const TabBarThemeData(
-          indicatorColor: Colors.white,
-        ),
+        tabBarTheme: const TabBarThemeData(indicatorColor: Colors.white),
       ),
       home: DefaultTabController(
         length: 2,
@@ -30,12 +28,8 @@ class App extends StatelessWidget {
           ),
           body: const TabBarView(
             children: [
-              Center(
-                child: HomePage(),
-              ),
-              Center(
-                child: APIPage(),
-              ),
+              Center(child: HomePage()),
+              Center(child: APIPage()),
             ],
           ),
         ),

--- a/example/lib/src/screen/api_page.dart
+++ b/example/lib/src/screen/api_page.dart
@@ -5,7 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_line_sdk/flutter_line_sdk.dart';
 
 class APIPage extends StatefulWidget {
-  const APIPage({Key? key}) : super(key: key);
+  const APIPage({super.key});
 
   @override
   State<StatefulWidget> createState() => _APIPageState();

--- a/example/lib/src/screen/home_page.dart
+++ b/example/lib/src/screen/home_page.dart
@@ -7,7 +7,7 @@ import '../theme.dart';
 import '../widget/user_info_widget.dart';
 
 class HomePage extends StatefulWidget {
-  const HomePage({Key? key}) : super(key: key);
+  const HomePage({super.key});
 
   @override
   State<StatefulWidget> createState() => _HomePageState();
@@ -118,43 +118,49 @@ class _HomePageState extends State<HomePage>
   }
 
   Widget _scopeListUI() => Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          const Text('Scopes: '),
-          Wrap(
-            children:
-                _scopes.map<Widget>((scope) => _buildScopeChip(scope)).toList(),
-          ),
-        ],
-      );
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: <Widget>[
+      const Text('Scopes: '),
+      Wrap(
+        children: _scopes
+            .map<Widget>((scope) => _buildScopeChip(scope))
+            .toList(),
+      ),
+    ],
+  );
 
   Widget _buildScopeChip(String scope) => Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 4.0),
-        child: ChipTheme(
-          data: ChipTheme.of(context).copyWith(brightness: Brightness.dark),
-          child: FilterChip(
-            label: Text(scope, style: const TextStyle(color: textColor)),
-            selectedColor: accentColor,
-            backgroundColor: secondaryBackgroundColor,
-            selected: _selectedScopes.contains(scope),
-            onSelected: (_) {
-              setState(() {
-                _selectedScopes.contains(scope)
-                    ? _selectedScopes.remove(scope)
-                    : _selectedScopes.add(scope);
-              });
-            },
-          ),
-        ),
-      );
+    padding: const EdgeInsets.symmetric(horizontal: 4.0),
+    child: ChipTheme(
+      data: ChipTheme.of(context).copyWith(brightness: Brightness.dark),
+      child: FilterChip(
+        label: Text(scope, style: const TextStyle(color: textColor)),
+        selectedColor: accentColor,
+        backgroundColor: secondaryBackgroundColor,
+        selected: _selectedScopes.contains(scope),
+        onSelected: (_) {
+          setState(() {
+            _selectedScopes.contains(scope)
+                ? _selectedScopes.remove(scope)
+                : _selectedScopes.add(scope);
+          });
+        },
+      ),
+    ),
+  );
 
   void _signIn() async {
     try {
       /// requestCode is for Android platform only, use another unique value in your application.
-      final loginOption =
-          LoginOption(_isOnlyWebLogin, 'normal', requestCode: 8192);
-      final result = await LineSDK.instance
-          .login(scopes: _selectedScopes.toList(), option: loginOption);
+      final loginOption = LoginOption(
+        _isOnlyWebLogin,
+        'normal',
+        requestCode: 8192,
+      );
+      final result = await LineSDK.instance.login(
+        scopes: _selectedScopes.toList(),
+        option: loginOption,
+      );
       final accessToken = await LineSDK.instance.currentAccessToken;
 
       final userEmail = result.accessToken.email;

--- a/example/lib/src/widget/user_info_widget.dart
+++ b/example/lib/src/widget/user_info_widget.dart
@@ -4,12 +4,12 @@ import '../theme.dart';
 
 class UserInfoWidget extends StatelessWidget {
   const UserInfoWidget({
-    Key? key,
+    super.key,
     required this.userProfile,
     this.userEmail,
     required this.accessToken,
     required this.onSignOutPressed,
-  }) : super(key: key);
+  });
 
   final UserProfile userProfile;
   final String? userEmail;
@@ -23,11 +23,7 @@ class UserInfoWidget extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
           (userProfile.pictureUrl ?? "").isNotEmpty
-              ? Image.network(
-                  userProfile.pictureUrl!,
-                  width: 200,
-                  height: 200,
-                )
+              ? Image.network(userProfile.pictureUrl!, width: 200, height: 200)
               : const Icon(Icons.person),
           Text(
             userProfile.displayName,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -118,10 +118,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -179,10 +179,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -200,5 +200,5 @@ packages:
     source: hosted
     version: "15.0.0"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.38.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -200,5 +200,5 @@ packages:
     source: hosted
     version: "15.0.0"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
-  flutter: ">=3.38.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 2.7.2+323
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: '>=3.12.0 <4.0.0'
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,8 +5,8 @@ homepage: https://developers.line.biz/
 repository: https://github.com/line/flutter_line_sdk/
 
 environment:
-  sdk: '>=3.8.0 <4.0.0'
-  flutter: ">=3.38.0"
+  sdk: '>=3.12.0 <4.0.0'
+  flutter: ">=3.44.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary

- Supersedes #134, fixes #148.
- **Commit 1** aligns the Android toolchain of the plugin and the example app with current Flutter stable (3.44.7): AGP 8.11.1, Kotlin 2.2.20, Gradle 8.14, compileSdk 36, Java 17, coroutines 1.8.1. The old toolchain was below Flutter 3.44's hard minimums (Gradle 8.7 / AGP 8.6), so the example no longer built on stable at all.
- **Commit 2** completes the migration to [Flutter's built-in Kotlin](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors): the plugin no longer applies KGP, `android.kotlinOptions` moves to the top-level `kotlin.compilerOptions`, and both projects adopt the Flutter 3.44 template versions (AGP 9.0.1 / Kotlin 2.3.20 / Gradle 9.1.0). This raises the requirement to Flutter >= 3.44.0 / Dart >= 3.12.0.

Because of the new Flutter minimum, this should ship as a **major release (3.0.0)**, keeping 2.x available for users on older Flutter — as also suggested in the discussion on #134. Version bump and CHANGELOG will be handled by the usual release flow after merge.

## Why the AGP-version guard was not enough

The `if (agpMajor < 9) { apply plugin: 'kotlin-android' }` guard on master turned out to be insufficient, in two ways (verified against the flutter_tools source and reproduced locally on 3.44.7):

1. Flutter's migration check scans the Gradle **script text** line by line (`kgpRegexGroovy` in `FlutterPluginUtils.kt`), so the guarded `apply` still counts as "plugin applies KGP" and triggers the warning reported in #148 whenever the app runs AGP 9+.
2. Worse, under AGP 9 the two mechanisms contradict each other at runtime: the guard skips applying KGP, while the text scan makes Flutter believe the plugin applies it on its own — so Flutter does not apply it either. The plugin's Kotlin sources are then never compiled and the app build fails with:

```
error: cannot find symbol
      flutterEngine.getPlugins().add(new com.linecorp.flutter_line_sdk.FlutterLineSdkPlugin());
```

This is exactly the build failure class reported in #148. After this migration, Flutter applies KGP to the plugin project itself and `:flutter_line_sdk:compileDebugKotlin` runs again.

## Verification (all local, Flutter 3.44.7 stable / Xcode 27 / macOS)

| Check | Result |
| --- | --- |
| `master` example vs Flutter 3.44.7 | ❌ fails to configure (Gradle 8.6 < min 8.7; AGP 8.4 < min 8.6) — motivation for commit 1 |
| Guarded plugin + AGP 9.0.1 example (state between the commits) | ❌ reproduces the #148 warning (`plugins that apply KGP: flutter_line_sdk`) and fails with the missing-symbol error above |
| This PR, `gradlew assembleDebug` + `flutter build apk` (debug & release) | ✅ builds, `:flutter_line_sdk:compileDebugKotlin` executed, zero KGP/deprecation warnings from Flutter |
| `flutter analyze --fatal-infos` / `flutter test` | ✅ clean / 7 passed (same commands as CI) |
| Old Flutter negative test (3.41.6, Dart 3.11.4) | ✅ `pub get` fails fast with a clear constraint message suggesting Flutter 3.44.7 |

## Notes

- The example app picks up a few Flutter/AGP auto-migrations along the way: `gradle.properties` flags (`android.newDsl=false`, `android.builtInKotlin=false`, matching what `flutter create` generates on 3.44), removal of the manifest `package` attribute (ignored since AGP 9), SPM package references added to the Xcode project by the Flutter tool, and `use_super_parameters` lint fixes surfaced by the Dart language version bump.
- Out of scope, noticed during verification: Flutter 3.44 warns that `ios/flutter_line_sdk/Package.swift` is missing a `FlutterFramework` dependency under the new SPM plugin guideline — worth a small follow-up PR. Also, Xcode 27 (beta) raises the minimum deployment target to 15.0, so the *example* iOS app fails its integrity check there; both pre-exist on master and are unrelated to the Android migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
